### PR TITLE
fix : security config 파일 생성

### DIFF
--- a/src/main/java/com/example/myspringsecurityproject/common/SecurityConfig.java
+++ b/src/main/java/com/example/myspringsecurityproject/common/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.example.myspringsecurityproject.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+
+        httpSecurity
+                .cors().disable()
+                .csrf().disable()
+                .headers()
+                .and()
+                .authorizeRequests().antMatchers("/", "/login").permitAll()
+                .and()
+                .authorizeRequests().antMatchers("/admin/**").hasRole("ADMIN")
+                .and()
+                .authorizeRequests().antMatchers("/manage/**").hasAnyRole("ADMIN", "MANAGER")
+                .and()
+                .authorizeRequests().anyRequest().authenticated()
+                .and()
+                .formLogin()
+                .loginPage("/login");
+
+        return httpSecurity.build();
+    }
+}


### PR DESCRIPTION
- '/'와 '/login'로 이동시에는 인증하지 않음
- 요청이 '/admin/' 으로 시작하는 경우에는 admin role 유저만 접근가능
- 요청이 '/manage/'으로 시작하는 경우에는 admin과 manager만 접근가능
- 로그인 페이지는 요청이 '/login'으로 들어오면 login.jsp를 보여주도록 설정

Ref #1